### PR TITLE
PR fix #76

### DIFF
--- a/gdc_lib_main/functions/gdc_lucy/moves/fn_lucyGroupRandomPatrol.sqf
+++ b/gdc_lib_main/functions/gdc_lucy/moves/fn_lucyGroupRandomPatrol.sqf
@@ -60,5 +60,5 @@ _wp = [
     _grp_params #4,
     15, 
     [0, _wp_timeout/2, _wp_timeout], 
-    ["true", format["nul = [this] spawn {[group (_this select 0), %1, [%2,""UNCHANGED"",""UNCHANGED"",""NO CHANGE"",""NO CHANGE""], %3] call GDC_fnc_lucyGroupRandomPatrol;};", _mkr_param, str(_grp_params #0), _blacklist]]
+    ["true", format["if (local this) then {nul = [this] spawn {[group (_this select 0), %1, [%2,""UNCHANGED"",""UNCHANGED"",""NO CHANGE"",""NO CHANGE""], %3] call GDC_fnc_lucyGroupRandomPatrol;};};", _mkr_param, str(_grp_params #0), _blacklist]]
 ] call GDC_fnc_lucyAddWaypoint;

--- a/gdc_lib_main/functions/gdc_lucy/moves/fn_lucyGroupRandomPatrol.sqf
+++ b/gdc_lib_main/functions/gdc_lucy/moves/fn_lucyGroupRandomPatrol.sqf
@@ -65,8 +65,10 @@ _wp = [
         format[
             "
             if (local this && count waypoints this) then {
-                private _group = ;
-                deleteWaypoint [group this, 0];
+                for ""_i"" from count waypoints _group - 1 to 0 step -1 do
+                {
+	                deleteWaypoint [_group, _i];
+                };
                 nul = [this] spawn {[group (_this#0), %1, [%2,""UNCHANGED"",""UNCHANGED"",""NO CHANGE"",""NO CHANGE""], %3] call skst_fnc_lucyGroupRandomPatrol;};
             };",
             _mkr_param,

--- a/gdc_lib_main/functions/gdc_lucy/moves/fn_lucyGroupRandomPatrol.sqf
+++ b/gdc_lib_main/functions/gdc_lucy/moves/fn_lucyGroupRandomPatrol.sqf
@@ -70,7 +70,7 @@ _wp = [
                 {
 	                deleteWaypoint [_group, _i];
                 };
-                nul = _group spawn {[_this, %1, [%2,""UNCHANGED"",""UNCHANGED"",""NO CHANGE"",""NO CHANGE""], %3] call skst_fnc_lucyGroupRandomPatrol;};
+                nul = _group spawn {[_this, %1, [%2,""UNCHANGED"",""UNCHANGED"",""NO CHANGE"",""NO CHANGE""], %3] call GDC_fnc_lucyGroupRandomPatrol;};
             };",
             _mkr_param,
             str(_grp_params #0),

--- a/gdc_lib_main/functions/gdc_lucy/moves/fn_lucyGroupRandomPatrol.sqf
+++ b/gdc_lib_main/functions/gdc_lucy/moves/fn_lucyGroupRandomPatrol.sqf
@@ -60,5 +60,17 @@ _wp = [
     _grp_params #4,
     15, 
     [0, _wp_timeout/2, _wp_timeout], 
-    ["true", format["if (local this && (count waypoints group this) < 3) then {nul = [this] spawn {[group (_this select 0), %1, [%2,""UNCHANGED"",""UNCHANGED"",""NO CHANGE"",""NO CHANGE""], %3] call GDC_fnc_lucyGroupRandomPatrol;};};", _mkr_param, str(_grp_params #0), _blacklist]]
+    [
+        "true",
+        format[
+            "
+            if (local this && count waypoints this) then {
+                private _group = ;
+                deleteWaypoint [group this, 0];
+                nul = [this] spawn {[group (_this#0), %1, [%2,""UNCHANGED"",""UNCHANGED"",""NO CHANGE"",""NO CHANGE""], %3] call skst_fnc_lucyGroupRandomPatrol;};
+            };",
+            _mkr_param,
+            str(_grp_params #0),
+            _blacklist]
+        ]
 ] call GDC_fnc_lucyAddWaypoint;

--- a/gdc_lib_main/functions/gdc_lucy/moves/fn_lucyGroupRandomPatrol.sqf
+++ b/gdc_lib_main/functions/gdc_lucy/moves/fn_lucyGroupRandomPatrol.sqf
@@ -60,5 +60,5 @@ _wp = [
     _grp_params #4,
     15, 
     [0, _wp_timeout/2, _wp_timeout], 
-    ["true", format["if (local this) then {nul = [this] spawn {[group (_this select 0), %1, [%2,""UNCHANGED"",""UNCHANGED"",""NO CHANGE"",""NO CHANGE""], %3] call GDC_fnc_lucyGroupRandomPatrol;};};", _mkr_param, str(_grp_params #0), _blacklist]]
+    ["true", format["if (local this && (count waypoints group this) < 3) then {nul = [this] spawn {[group (_this select 0), %1, [%2,""UNCHANGED"",""UNCHANGED"",""NO CHANGE"",""NO CHANGE""], %3] call GDC_fnc_lucyGroupRandomPatrol;};};", _mkr_param, str(_grp_params #0), _blacklist]]
 ] call GDC_fnc_lucyAddWaypoint;

--- a/gdc_lib_main/functions/gdc_lucy/moves/fn_lucyGroupRandomPatrol.sqf
+++ b/gdc_lib_main/functions/gdc_lucy/moves/fn_lucyGroupRandomPatrol.sqf
@@ -21,7 +21,6 @@
 */
 
 params ["_group", "_mkr_param", ["_grp_params", ["MOVE", "LIMITED", "SAFE", "RED", "COLUMN"], [[]], [5]], ["_blacklist", nil, [[], ""]]];
-
 private ["_random_pos", "_wp", "_wp_timeout"];
 
 // If no blacklist sended, we generate the right one
@@ -66,11 +65,12 @@ _wp = [
         format[
             "
             if (local this) then {
+                private _group = group this;
                 for ""_i"" from count waypoints _group - 1 to 0 step -1 do
                 {
 	                deleteWaypoint [_group, _i];
                 };
-                nul = [this] spawn {[group (_this#0), %1, [%2,""UNCHANGED"",""UNCHANGED"",""NO CHANGE"",""NO CHANGE""], %3] call skst_fnc_lucyGroupRandomPatrol;};
+                nul = _group spawn {[_this, %1, [%2,""UNCHANGED"",""UNCHANGED"",""NO CHANGE"",""NO CHANGE""], %3] call skst_fnc_lucyGroupRandomPatrol;};
             };",
             _mkr_param,
             str(_grp_params #0),

--- a/gdc_lib_main/functions/gdc_lucy/moves/fn_lucyGroupRandomPatrol.sqf
+++ b/gdc_lib_main/functions/gdc_lucy/moves/fn_lucyGroupRandomPatrol.sqf
@@ -21,6 +21,7 @@
 */
 
 params ["_group", "_mkr_param", ["_grp_params", ["MOVE", "LIMITED", "SAFE", "RED", "COLUMN"], [[]], [5]], ["_blacklist", nil, [[], ""]]];
+
 private ["_random_pos", "_wp", "_wp_timeout"];
 
 // If no blacklist sended, we generate the right one
@@ -64,7 +65,7 @@ _wp = [
         "true",
         format[
             "
-            if (local this && count waypoints this) then {
+            if (local this) then {
                 for ""_i"" from count waypoints _group - 1 to 0 step -1 do
                 {
 	                deleteWaypoint [_group, _i];

--- a/gdc_lib_main/functions/util/fn_addZeusToPlayer.sqf
+++ b/gdc_lib_main/functions/util/fn_addZeusToPlayer.sqf
@@ -24,7 +24,7 @@ _curator addCuratorEditableObjects [allUnits,true];
 _curator addCuratorEditableObjects [vehicles,true];
 _player assignCurator _curator;
 
-diag_log format ["Zeus modul created : %1, unit linked, %2", _curator, _player];
+diag_log format ["Zeus module created : %1, unit linked, %2", _curator, _player];
 ["Zeus créé sur le serveur"] remoteExec ["systemChat"];
 
 [_curator, _player]


### PR DESCRIPTION
Ajout de la contrainte `if (local this) then {<code>};` dans le waypoint statement. Cela devrait restreindre l'execution à la machine locale de l'unité et donc éviter les multiples waypoints.

Tests non faits pour l'instant.