### PR TITLE
Reworked PLUTO transmitted data

### DIFF
--- a/gdc_lib_main/functions/gdc_pluto/fn_plutoAction.sqf
+++ b/gdc_lib_main/functions/gdc_pluto/fn_plutoAction.sqf
@@ -25,7 +25,7 @@ private ["_unit","_group","_count","_targetList","_range"];
 	};
 	_range = _x getVariable ["PLUTO_REVEALRANGE",_range]; // Eventuel range custom
 	// Parmi la liste de cibles disponibles ne sélectionner que celles qui sont dans le Range et qui ne sont pas déjà connues par le groupe :
-	_targetList = gdc_plutoTargetList select {((_unit distance _x) < _range)};
+	_targetList = gdc_plutoTargetList select {((_unit distance _x) < _range) && ((_unit knowsAbout _x) < 1.5)};
 	// Révéler les cibles ainsi sélectionnées :
 	{
 		_group reveal _x;

--- a/gdc_lib_main/functions/gdc_pluto/fn_plutoAction.sqf
+++ b/gdc_lib_main/functions/gdc_pluto/fn_plutoAction.sqf
@@ -25,10 +25,10 @@ private ["_unit","_group","_count","_targetList","_range"];
 	};
 	_range = _x getVariable ["PLUTO_REVEALRANGE",_range]; // Eventuel range custom
 	// Parmi la liste de cibles disponibles ne sélectionner que celles qui sont dans le Range et qui ne sont pas déjà connues par le groupe :
-	_targetList = gdc_plutoTargetList select {((_unit distance (_x #0)) < _range) && ((_unit knowsAbout (_x #0)) < 1)};
+	_targetList = gdc_plutoTargetList select {((_unit distance _x) < _range)};
 	// Révéler les cibles ainsi sélectionnées :
 	{
-		_group reveal [(_x #0),(_x #1)];
+		_group reveal _x;
 	} forEach _targetList;
 	// Si des cibles ont été révélées, générer des actions en fonction des ordres des unités
 	_count = count _targetList;
@@ -36,9 +36,10 @@ private ["_unit","_group","_count","_targetList","_range"];
 		// DEBUG
 		if (gdc_plutoDebug) then {systemChat ((str _count) + " units revealed to " + (str _group));};
 		// Actions en fonction de la variable
+		_targetList = _targetList select {(_unit knowsAbout _x) >= 1}; // Ne lancer des actions spéciales que si la cible est suffisament connue
 		switch (_group getVariable ["PLUTO_ORDER","DEFAULT"]) do {
-			case "QRF": {[_group,((flatten _targetList) select {(typeName _x) == "OBJECT"})] call gdc_fnc_plutoDoQRF;};
-			case "ARTY": {[_group,((flatten _targetList) select {(typeName _x) == "OBJECT"})] call gdc_fnc_plutoDoArty;};
+			case "QRF": {[_group,_targetList] call gdc_fnc_plutoDoQRF;};
+			case "ARTY": {[_group,_targetList] call gdc_fnc_plutoDoArty;};
 			case "IGNORE";
 			case "DEFAULT";
 			default {};

--- a/gdc_lib_main/functions/gdc_pluto/fn_plutoAnalize.sqf
+++ b/gdc_lib_main/functions/gdc_pluto/fn_plutoAnalize.sqf
@@ -43,8 +43,8 @@ gdc_plutoTargetList = [];
 		// Vérifier que la cible n'est pas le HC, qu'elle n'est pas déjà dans la liste, qu'elle n'est pas amie et qu'elle est bien réelle
 		if ((_target != HC_Slot) && !(_target in gdc_plutoTargetList) && (_targetSide != gdc_plutoSide) && ((gdc_plutoSide getFriend _targetSide) < 0.6) && (_target iskindof "AllVehicles")) then {
 			// Vérifier que la cible est vivante, que le groupe a suffisament d'infos sur la cible et que la cible n'est pas captive
-			if ((alive _target) && ((_unit knowsAbout _target) > 1.5) && (_targetPosAcc < 20) && (!captive _target)) then {
-				gdc_plutoTargetList = gdc_plutoTargetList + [[_target,(_unit knowsAbout _target)]]; // ajouter la cible dans la liste
+			if ((alive _target) && ((_unit knowsAbout _target) >= 0.2) && (!captive _target)) then {
+				gdc_plutoTargetList = gdc_plutoTargetList + [_target]; // ajouter la cible dans la liste
 				// DEBUG
 				if (gdc_plutoDebug) then {
 					_mk = createMarkerLocal [(format ["mk_target%1",_target]),_targetPos];


### PR DESCRIPTION
More targets should be shared with PLUTO now.
- Removed targetknowledge from transmitted data (best side value is shared instead)
- Lowered target knowledge threshold
- QRF and ARTY will not act on badly known targets